### PR TITLE
Triangle color to match top background of inline-editor

### DIFF
--- a/webcomponents/inline-editor/src/components/components/triangle/triangle.scss
+++ b/webcomponents/inline-editor/src/components/components/triangle/triangle.scss
@@ -16,7 +16,7 @@ div.triangle {
     position: absolute;
     width: 24px;
     height: 24px;
-    background: white;
+    background: var(--deckgo-inline-editor-background-top, white);
     transform: rotate(45deg);
     top: 28px;
     left: 8px;


### PR DESCRIPTION
Use --deckgo-inline-editor-background-top for triangle if given.

This makes it possible to add dark mode code that also colors the triangle rather than just the bar. ie.

```
body.dark {
  --deckgo-inline-editor-button-color: white;
  --deckgo-inline-editor-background-bottom: black;
  --deckgo-inline-editor-background-top: black;
  --deckgo-inline-editor-link-color: white;
  --deckgo-inline-editor-link-placeholder-color: white;
}
```

Alternative: create new variable for triangle color.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Apologies, not sure how to run the tests on this component yet.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using `x` and remove the others. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes

## Other information

<!-- Please provide any useful other information. -->

Issue Number: N/A
